### PR TITLE
Add k8s patroni monitoring

### DIFF
--- a/config/k8s-patroni.txt
+++ b/config/k8s-patroni.txt
@@ -1,0 +1,31 @@
+k8s-patroni
+
+This patroni monitoring works by running a script as a sidecar.
+This script writes all statuses available in the container to a configmap.
+These confimaps are automaticly discovered by the zabbix agent.
+
+To use the patroni monitoring you have to do the following steps:
+
+1. Label the to be monitored namespaces `patroni-postgres-monitoring=true`
+2. Create a ubuntu sidecar in all patroni pods to be monitored.
+3. Give this sidecar a service account to create configmaps
+3. Mount the script (below) to the sidecar, and make it run in a loop.
+4. Load the template and enable the template for the hosts*.
+
+* The hosts should have kubectl and acces to the cluster and namespaces. 
+* You have to manualy create the config maps the first time. 
+* The serviceaccount only needs patch permissions, and can be limited to only the monitored namespaces.
+
+script:
+```
+while :
+do
+    STATUS=$(curl localhost:8008/cluster -s | sed 's/"/\\"/g' );
+    CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+    PAYLOAD="[{\"op\" : \"replace\", \"path\" : \"/data/status\", \"value\" : \"${STATUS}\" }]"
+    curl --cacert ${CA_CERT} --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    --header "Content-Type: application/json-patch+json" --request PATCH --data "${PAYLOAD}" \
+    https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/${POD_NAME} -k
+    sleep 30
+done
+```

--- a/config/k8s-patroni.txt
+++ b/config/k8s-patroni.txt
@@ -1,31 +1,38 @@
 k8s-patroni
+===========
 
-This patroni monitoring works by running a script as a sidecar.
+The k8s patroni monitoring works by running a script as a sidecar.
 This script writes all statuses available in the container to a configmap.
-These confimaps are automaticly discovered by the zabbix agent.
+These configmaps are automatically discovered by the zabbix-agent.
 
 To use the patroni monitoring you have to do the following steps:
 
-1. Label the to be monitored namespaces `patroni-postgres-monitoring=true`
-2. Create a ubuntu sidecar in all patroni pods to be monitored.
-3. Give this sidecar a service account to create configmaps
-3. Mount the script (below) to the sidecar, and make it run in a loop.
-4. Load the template and enable the template for the hosts*.
+1. Label the namespaces to be monitored with
+   `ossobv/zabbix-agent-osso.k8s-patroni=true`.
 
-* The hosts should have kubectl and acces to the cluster and namespaces. 
-* You have to manualy create the config maps the first time. 
-* The serviceaccount only needs patch permissions, and can be limited to only the monitored namespaces.
+2. Create an Ubuntu sidecar in all patroni pods to be monitored.
 
-script:
-```
-while :
-do
-    STATUS=$(curl localhost:8008/cluster -s | sed 's/"/\\"/g' );
-    CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
-    PAYLOAD="[{\"op\" : \"replace\", \"path\" : \"/data/status\", \"value\" : \"${STATUS}\" }]"
-    curl --cacert ${CA_CERT} --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-    --header "Content-Type: application/json-patch+json" --request PATCH --data "${PAYLOAD}" \
-    https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/${POD_NAME} -k
-    sleep 30
-done
-```
+3. Give this sidecar a serviceaccount to create configmaps.
+
+4. Mount the script (below) to the sidecar, and make it run in a loop.
+
+5. Load the template and enable the template for the hosts:
+
+   - The hosts should have kubectl and access to the cluster and namespaces.
+   - You have to manually create the configmaps the first time.
+   - The serviceaccount needs only patch permissions, and can be limited
+     to only the monitored namespaces.
+
+Script:
+
+    # FIXME: secret in args!
+    CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    while :; do
+        STATUS=$(curl localhost:8008/cluster -s | sed 's/"/\\"/g' )
+        PAYLOAD='[{"op":"replace","path":"/data/status","value":"'"${STATUS}"'"}]'
+        curl --cacert ${CA_CERT} \
+          --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+          --header "Content-Type: application/json-patch+json" --request PATCH --data "${PAYLOAD}" \
+          https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/${POD_NAME}
+        sleep 30
+    done

--- a/config/k8s-patroni.txt
+++ b/config/k8s-patroni.txt
@@ -34,7 +34,7 @@ Script:
         PAYLOAD='[{"op":"replace","path":"/data/status","value":"'"${STATUS}"'"}]'
         curl --request PATCH --cacert ${CA_CERT} \
           --header @/tmp/auth --header "Content-Type: application/json-patch+json" \
-          -data "${PAYLOAD}" \
+          --data "${PAYLOAD}" \
           https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/status-${POD_NAME}
         sleep 30
     done

--- a/config/k8s-patroni.txt
+++ b/config/k8s-patroni.txt
@@ -34,7 +34,7 @@ Script:
         PAYLOAD='[{"op":"replace","path":"/data/status","value":"'"${STATUS}"'"}]'
         curl --request PATCH --cacert ${CA_CERT} \
           --header @/tmp/auth --header "Content-Type: application/json-patch+json" \
-          --data "${PAYLOAD}" \
-          https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/${POD_NAME}
+          -data "${PAYLOAD}" \
+          https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/status-${POD_NAME}
         sleep 30
     done

--- a/config/k8s-patroni.txt
+++ b/config/k8s-patroni.txt
@@ -14,25 +14,27 @@ To use the patroni monitoring you have to do the following steps:
 
 3. Give this sidecar a serviceaccount to create configmaps.
 
+   - You have to manually create the configmaps the first time;
+   - the serviceaccount needs only patch permissions, and can be limited
+     to only the monitored namespaces.
+
 4. Mount the script (below) to the sidecar, and make it run in a loop.
 
 5. Load the template and enable the template for the hosts:
 
    - The hosts should have kubectl and access to the cluster and namespaces.
-   - You have to manually create the configmaps the first time.
-   - The serviceaccount needs only patch permissions, and can be limited
-     to only the monitored namespaces.
 
 Script:
 
-    # FIXME: secret in args!
+    umask 0077
+    sed -e 's/^/Authorization: Bearer /' /var/run/secrets/kubernetes.io/serviceaccount/token >/tmp/auth
     CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     while :; do
         STATUS=$(curl localhost:8008/cluster -s | sed 's/"/\\"/g' )
         PAYLOAD='[{"op":"replace","path":"/data/status","value":"'"${STATUS}"'"}]'
-        curl --cacert ${CA_CERT} \
-          --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-          --header "Content-Type: application/json-patch+json" --request PATCH --data "${PAYLOAD}" \
+        curl --request PATCH --cacert ${CA_CERT} \
+          --header @/tmp/auth --header "Content-Type: application/json-patch+json" \
+          --data "${PAYLOAD}" \
           https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/${POD_NAME}
         sleep 30
     done

--- a/scripts/k8s-patroni
+++ b/scripts/k8s-patroni
@@ -25,19 +25,19 @@ make_json() {
     kubectl -n "$namespace" --context "$context" get cm "$name" \
             -o jsonpath='{.data.status}' |
         jq -r '.members[] | {"{#CONTEXT}":"'$context'","{#NAMESPACE}":'"\
-"'"'$namespace'","{#CONFIGMAP}":"'$name'","{#MEMBER}":.name}'
+"'"'$namespace'","{#POD}":"'$name'","{#MEMBER}":.name}'
 }
 
 if [ "$1" = "--discover" ]; then
     for context in $(get_contexts); do 
         for namespace in $(get_namespaces "$context"); do
             for name in $(get_configmaps "$namespace" "$context"); do
-                make_json "$namespace" "$context" "$name"
+                make_json "$namespace" "$context" "${name#status-}"
             done
         done
     done | jq -sc
     exit 0
 fi
 
-exec kubectl --context "$1" -n "$2" get cm "$3" -o jsonpath='{.data.status}' |
+exec kubectl --context "$1" -n "$2" get cm "status-$3" -o jsonpath='{.data.status}' |
     jq '.members[] | select(.name == "'"$4"'")'

--- a/scripts/k8s-patroni
+++ b/scripts/k8s-patroni
@@ -11,20 +11,21 @@ get_contexts() {
 }
 
 get_namespaces() {
-    kubectl get namespace -l patroni-postgres-monitoring=true \
-        --context $1 --no-headers 2>/dev/null \
-    | sed -e 's/namespace\///' 
+    kubectl get namespace -l ossobv/zabbix-agent-osso.k8s-patroni=true \
+            --context "$1" --no-headers 2>/dev/null |
+        sed -e 's/namespace\///'
 }
 
 get_configmaps() {
-    kubectl -n $1 --context $2 get cm -o name \
-    | sed -e 's/^configmap\///;/^citus-/!d'
+    kubectl -n "$1" --context "$2" get cm -o name |
+        sed -e 's/^configmap\///;/^citus-/!d'
 }
 
 make_json() {
-    kubectl -n $namespace --context $context get cm $name \
-        -o jsonpath='{.data.status}' \
-    | jq -r '.members[] | {"{#CONTEXT}":"'$context'","{#NAMESPACE}":"'$namespace'","{#CONFIGMAP}":"'$name'","{#MEMBER}":.name}'; 
+    kubectl -n "$namespace" --context "$context" get cm "$name" \
+            -o jsonpath='{.data.status}' |
+        jq -r '.members[] | {"{#CONTEXT}":"'$context'","{#NAMESPACE}":'"\
+"'"'$namespace'","{#CONFIGMAP}":"'$name'","{#MEMBER}":.name}'
 }
 
 if [ "$1" = "--discover" ]; then

--- a/scripts/k8s-patroni
+++ b/scripts/k8s-patroni
@@ -29,7 +29,7 @@ make_json() {
 }
 
 if [ "$1" = "--discover" ]; then
-    for context in $(get_contexts); do 
+    for context in $(get_contexts); do
         for namespace in $(get_namespaces "$context"); do
             for name in $(get_configmaps "$namespace" "$context"); do
                 make_json "$namespace" "$context" "${name#status-}"

--- a/scripts/k8s-patroni
+++ b/scripts/k8s-patroni
@@ -1,0 +1,42 @@
+#!/bin/sh
+# [This file is part of the zabbix-agent-osso package]
+# REQUIRES: kubectl
+#
+#UserParameter=k8s-patroni.discovery, sudo /etc/zabbix/scripts/k8s-patroni --discover
+#UserParameter=k8s-patroni.values[*], sudo /etc/zabbix/scripts/k8s-patroni "$1" "$2" "$3" "$4"
+#
+
+get_contexts() {
+    kubectl config get-contexts -oname
+}
+
+get_namespaces() {
+    kubectl get namespace -l patroni-postgres-monitoring=true \
+        --context $1 --no-headers 2>/dev/null \
+    | sed -e 's/namespace\///' 
+}
+
+get_configmaps() {
+    kubectl -n $1 --context $2 get cm -o name \
+    | sed -e 's/^configmap\///;/^citus-/!d'
+}
+
+make_json() {
+    kubectl -n $namespace --context $context get cm $name \
+        -o jsonpath='{.data.status}' \
+    | jq -r '.members[] | {"{#CONTEXT}":"'$context'","{#NAMESPACE}":"'$namespace'","{#CONFIGMAP}":"'$name'","{#MEMBER}":.name}'; 
+}
+
+if [ "$1" = "--discover" ]; then
+    for context in $(get_contexts); do 
+        for namespace in $(get_namespaces "$context"); do
+            for name in $(get_configmaps "$namespace" "$context"); do
+                make_json "$namespace" "$context" "$name"
+            done
+        done
+    done | jq -sc
+    exit 0
+fi
+
+exec kubectl --context "$1" -n "$2" get cm "$3" -o jsonpath='{.data.status}' |
+    jq '.members[] | select(.name == "'"$4"'")'

--- a/sudoers.d/zabbix-patroni
+++ b/sudoers.d/zabbix-patroni
@@ -1,0 +1,5 @@
+# [This file is part of the zabbix-agent-osso package]
+#
+Cmnd_Alias PATRONI = /etc/zabbix/scripts/k8s-patroni *
+Defaults!PATRONI !log_allowed, !pam_session
+zabbix ALL=NOPASSWD: PATRONI

--- a/templates/Template k8s-patroni.xml
+++ b/templates/Template k8s-patroni.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>6.4</version>
+    <template_groups>
+        <template_group>
+            <uuid>846977d1dfed4968bc5f8bdb363285bc</uuid>
+            <name>Templates/Operating systems</name>
+        </template_group>
+    </template_groups>
+    <templates>
+        <template>
+            <uuid>5fb1060cf5a2426e98238808c7401bb7</uuid>
+            <template>Template ks8-patroni postgres status</template>
+            <name>Template ks8-patroni postgres status</name>
+            <groups>
+                <group>
+                    <name>Templates/Operating systems</name>
+                </group>
+            </groups>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>f690a7b15b744ca7aac4f6329a38941e</uuid>
+                    <name>Postgres status discovery</name>
+                    <type>ZABBIX_ACTIVE</type>
+                    <key>k8s-patroni.discovery</key>
+                    <description>discovery of the postgres statuses</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>d3cf71eb43ad4c61b07c549b33530c59</uuid>
+                            <name>Patroni {#MEMBER} lag</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.lag</parameter>
+                                    </parameters>
+                                    <error_handler>CUSTOM_VALUE</error_handler>
+                                    <error_handler_params>0</error_handler_params>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>012f08aa642845deaad34962e73066a5</uuid>
+                                    <expression>last(/Template ks8-patroni postgres status/k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],#3)&gt;0</expression>
+                                    <name>Patroni Postgres {#MEMBER} is having replication lag in namespace {#NAMESPACE}</name>
+                                    <priority>HIGH</priority>
+                                    <description>patroni postgres member is lagging behind with a value greater than 0</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>8b676ba7b4a64b438cb23d581d2ef8e4</uuid>
+                            <name>Patroni {#MEMBER} role</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.role</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>dfb182d4cc284e3a87db2d93182a7099</uuid>
+                                    <expression>change(/Template ks8-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
+                                    <name>Patroni Postgres {#MEMBER} changed role in namespace {#NAMESPACE}</name>
+                                    <priority>DISASTER</priority>
+                                    <description>patroni postgres role changed</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>7bdb1e8c62b5461cbddafd497b06f679</uuid>
+                                    <expression>nodata(/Template ks8-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],5m)=1</expression>
+                                    <name>Patroni Postgres {#MEMBER} not running in namespace {#NAMESPACE}</name>
+                                    <priority>DISASTER</priority>
+                                    <description>patroni postgres pod not running</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>bf27472e1ce842e3b4ae071fd010ccec</uuid>
+                            <name>Patroni {#MEMBER} state</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.state</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>1db0a53605ed426eaa1a2d8a237b844b</uuid>
+                                    <expression>change(/Template ks8-patroni postgres status/k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
+                                    <name>Patroni postgres {#MEMBER} state changed in namespace {#NAMESPACE}</name>
+                                    <priority>HIGH</priority>
+                                    <description>trigger for patroni postgres state change</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>b1d3cb168cd047eba5730f463c980cc9</uuid>
+                            <name>patroni-status {#MEMBER}</name>
+                            <type>ZABBIX_ACTIVE</type>
+                            <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <history>1h</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+        </template>
+    </templates>
+</zabbix_export>

--- a/templates/Template k8s-patroni.xml
+++ b/templates/Template k8s-patroni.xml
@@ -29,7 +29,7 @@
                             <uuid>d3cf71eb43ad4c61b07c549b33530c59</uuid>
                             <name>Patroni {#MEMBER} lag</name>
                             <type>DEPENDENT</type>
-                            <key>k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <key>k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
                             <delay>0</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
@@ -44,12 +44,12 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{POD},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>012f08aa642845deaad34962e73066a5</uuid>
-                                    <expression>last(/Template k8s-patroni postgres status/k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],#3)&gt;0</expression>
+                                    <expression>last(/Template k8s-patroni postgres status/k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}],#3)&gt;0</expression>
                                     <name>Patroni Postgres {#MEMBER} is having replication lag in namespace {#NAMESPACE}</name>
                                     <priority>HIGH</priority>
                                     <description>patroni postgres member is lagging behind with a value greater than 0</description>
@@ -60,7 +60,7 @@
                             <uuid>8b676ba7b4a64b438cb23d581d2ef8e4</uuid>
                             <name>Patroni {#MEMBER} role</name>
                             <type>DEPENDENT</type>
-                            <key>k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <key>k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
                             <delay>0</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
@@ -73,19 +73,19 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>dfb182d4cc284e3a87db2d93182a7099</uuid>
-                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
+                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}])=1</expression>
                                     <name>Patroni Postgres {#MEMBER} changed role in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                     <description>patroni postgres role changed</description>
                                 </trigger_prototype>
                                 <trigger_prototype>
                                     <uuid>7bdb1e8c62b5461cbddafd497b06f679</uuid>
-                                    <expression>nodata(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],5m)=1</expression>
+                                    <expression>nodata(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}],5m)=1</expression>
                                     <name>Patroni Postgres {#MEMBER} not running in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                     <description>patroni postgres pod not running</description>
@@ -96,7 +96,7 @@
                             <uuid>bf27472e1ce842e3b4ae071fd010ccec</uuid>
                             <name>Patroni {#MEMBER} state</name>
                             <type>DEPENDENT</type>
-                            <key>k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <key>k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
                             <delay>0</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
@@ -109,12 +109,12 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>1db0a53605ed426eaa1a2d8a237b844b</uuid>
-                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
+                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}])=1</expression>
                                     <name>Patroni postgres {#MEMBER} state changed in namespace {#NAMESPACE}</name>
                                     <priority>HIGH</priority>
                                     <description>trigger for patroni postgres state change</description>
@@ -125,7 +125,7 @@
                             <uuid>b1d3cb168cd047eba5730f463c980cc9</uuid>
                             <name>patroni-status {#MEMBER}</name>
                             <type>ZABBIX_ACTIVE</type>
-                            <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
                             <history>1h</history>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>

--- a/templates/Template k8s-patroni.xml
+++ b/templates/Template k8s-patroni.xml
@@ -21,15 +21,15 @@
                 <discovery_rule>
                     <uuid>f690a7b15b744ca7aac4f6329a38941e</uuid>
                     <name>Postgres status discovery</name>
-                    <type>ZABBIX_ACTIVE</type>
                     <key>k8s-patroni.discovery</key>
+                    <delay>1h</delay>
                     <description>discovery of the postgres statuses</description>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>d3cf71eb43ad4c61b07c549b33530c59</uuid>
                             <name>Patroni {#MEMBER} lag</name>
                             <type>DEPENDENT</type>
-                            <key>k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
+                            <key>k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             <delay>0</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
@@ -44,12 +44,12 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{POD},{#MEMBER}]</key>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>012f08aa642845deaad34962e73066a5</uuid>
-                                    <expression>last(/Template k8s-patroni postgres status/k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}],#3)&gt;0</expression>
+                                    <expression>last(/Template k8s-patroni postgres status/k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],#3)&gt;0</expression>
                                     <name>Patroni Postgres {#MEMBER} is having replication lag in namespace {#NAMESPACE}</name>
                                     <priority>HIGH</priority>
                                     <description>patroni postgres member is lagging behind with a value greater than 0</description>
@@ -60,7 +60,7 @@
                             <uuid>8b676ba7b4a64b438cb23d581d2ef8e4</uuid>
                             <name>Patroni {#MEMBER} role</name>
                             <type>DEPENDENT</type>
-                            <key>k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
+                            <key>k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             <delay>0</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
@@ -73,19 +73,19 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>dfb182d4cc284e3a87db2d93182a7099</uuid>
-                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}])=1</expression>
+                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
                                     <name>Patroni Postgres {#MEMBER} changed role in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                     <description>patroni postgres role changed</description>
                                 </trigger_prototype>
                                 <trigger_prototype>
                                     <uuid>7bdb1e8c62b5461cbddafd497b06f679</uuid>
-                                    <expression>nodata(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}],5m)=1</expression>
+                                    <expression>nodata(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],5m)=1</expression>
                                     <name>Patroni Postgres {#MEMBER} not running in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                     <description>patroni postgres pod not running</description>
@@ -96,7 +96,7 @@
                             <uuid>bf27472e1ce842e3b4ae071fd010ccec</uuid>
                             <name>Patroni {#MEMBER} state</name>
                             <type>DEPENDENT</type>
-                            <key>k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
+                            <key>k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             <delay>0</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
@@ -109,12 +109,12 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
+                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>1db0a53605ed426eaa1a2d8a237b844b</uuid>
-                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}])=1</expression>
+                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
                                     <name>Patroni postgres {#MEMBER} state changed in namespace {#NAMESPACE}</name>
                                     <priority>HIGH</priority>
                                     <description>trigger for patroni postgres state change</description>
@@ -124,9 +124,8 @@
                         <item_prototype>
                             <uuid>b1d3cb168cd047eba5730f463c980cc9</uuid>
                             <name>patroni-status {#MEMBER}</name>
-                            <type>ZABBIX_ACTIVE</type>
-                            <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#POD},{#MEMBER}]</key>
-                            <history>1h</history>
+                            <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <history>0</history>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                         </item_prototype>

--- a/templates/Template k8s-patroni.xml
+++ b/templates/Template k8s-patroni.xml
@@ -10,8 +10,8 @@
     <templates>
         <template>
             <uuid>5fb1060cf5a2426e98238808c7401bb7</uuid>
-            <template>Template ks8-patroni postgres status</template>
-            <name>Template ks8-patroni postgres status</name>
+            <template>Template k8s-patroni postgres status</template>
+            <name>Template k8s-patroni postgres status</name>
             <groups>
                 <group>
                     <name>Templates/Operating systems</name>
@@ -49,7 +49,7 @@
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>012f08aa642845deaad34962e73066a5</uuid>
-                                    <expression>last(/Template ks8-patroni postgres status/k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],#3)&gt;0</expression>
+                                    <expression>last(/Template k8s-patroni postgres status/k8s-patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],#3)&gt;0</expression>
                                     <name>Patroni Postgres {#MEMBER} is having replication lag in namespace {#NAMESPACE}</name>
                                     <priority>HIGH</priority>
                                     <description>patroni postgres member is lagging behind with a value greater than 0</description>
@@ -78,14 +78,14 @@
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>dfb182d4cc284e3a87db2d93182a7099</uuid>
-                                    <expression>change(/Template ks8-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
+                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
                                     <name>Patroni Postgres {#MEMBER} changed role in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                     <description>patroni postgres role changed</description>
                                 </trigger_prototype>
                                 <trigger_prototype>
                                     <uuid>7bdb1e8c62b5461cbddafd497b06f679</uuid>
-                                    <expression>nodata(/Template ks8-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],5m)=1</expression>
+                                    <expression>nodata(/Template k8s-patroni postgres status/k8s-patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],5m)=1</expression>
                                     <name>Patroni Postgres {#MEMBER} not running in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                     <description>patroni postgres pod not running</description>
@@ -114,7 +114,7 @@
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>1db0a53605ed426eaa1a2d8a237b844b</uuid>
-                                    <expression>change(/Template ks8-patroni postgres status/k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
+                                    <expression>change(/Template k8s-patroni postgres status/k8s-patroni.state[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])=1</expression>
                                     <name>Patroni postgres {#MEMBER} state changed in namespace {#NAMESPACE}</name>
                                     <priority>HIGH</priority>
                                     <description>trigger for patroni postgres state change</description>

--- a/zabbix_agentd.d/k8s-patroni.conf
+++ b/zabbix_agentd.d/k8s-patroni.conf
@@ -1,0 +1,7 @@
+# [This file is part of the zabbix-agent-osso package]
+#
+# DEPENDS: kubectl
+# SCRIPTS: k8s-patroni
+#
+UserParameter=k8s-patroni.discovery, sudo /etc/zabbix/scripts/k8s-patroni --discover
+UserParameter=k8s-patroni.values[*], sudo /etc/zabbix/scripts/k8s-patroni "$1" "$2" "$3" "$4"


### PR DESCRIPTION
adds kubernetes patroni status monitoring, with explanation adds: script, config, example template, sudoers.d file and zabbix_agentd.d config file (userparams)