### PR TITLE
k8s-patroni: extend monitoring with wal-g backup monitoring

### DIFF
--- a/config/k8s-patroni.txt
+++ b/config/k8s-patroni.txt
@@ -1,7 +1,7 @@
 k8s-patroni
 ===========
 
-The k8s patroni monitoring works by running a script as a sidecar.
+The k8s patroni monitoring works by running a script as a sidecar, or in cron.
 This script writes all statuses available in the container to a configmap.
 These configmaps are automatically discovered by the zabbix-agent.
 
@@ -10,31 +10,49 @@ To use the patroni monitoring you have to do the following steps:
 1. Label the namespaces to be monitored with
    `ossobv/zabbix-agent-osso.k8s-patroni=true`.
 
-2. Create an Ubuntu sidecar in all patroni pods to be monitored.
+2. Create an Ubuntu sidecar in all patroni pods to be monitored, or add the script to cron.
 
 3. Give this sidecar a serviceaccount to create configmaps.
 
    - You have to manually create the configmaps the first time;
+      kubectl create cm status-<status_name> --from-literal status=null
    - the serviceaccount needs only patch permissions, and can be limited
      to only the monitored namespaces.
 
-4. Mount the script (below) to the sidecar, and make it run in a loop.
+4. Mount the script (below) to the sidecar, and make it run every 30 seconds.
 
 5. Load the template and enable the template for the hosts:
 
    - The hosts should have kubectl and access to the cluster and namespaces.
 
+* for the wal-g env variables in cron you can use a mounted secret/conifgmap at /etc/wal-g.d/env, here you also define POD_NAMESPACE and STATUS_NAME.
+* patroni is accessed trough localhost because the cli needs multiple env variables we dont want to define in an extra configmap. ( it is a rest api anyways)
+
 Script:
 
+    #!/bin/bash
     umask 0077
-    sed -e 's/^/Authorization: Bearer /' /var/run/secrets/kubernetes.io/serviceaccount/token >/tmp/auth
-    CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    while :; do
-        STATUS=$(curl localhost:8008/cluster -s | sed 's/"/\\"/g' )
-        PAYLOAD='[{"op":"replace","path":"/data/status","value":"'"${STATUS}"'"}]'
-        curl --request PATCH --cacert ${CA_CERT} \
-          --header @/tmp/auth --header "Content-Type: application/json-patch+json" \
-          --data "${PAYLOAD}" \
-          https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/status-${POD_NAME}
-        sleep 30
-    done
+    ROLE=$(curl -s http://localhost:8008 | jq -r .role)
+    # there is only one master, use this to prevent double status checks.
+    if test $ROLE == "master"; then
+      CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+      sed -e 's/^/Authorization: Bearer /' /var/run/secrets/kubernetes.io/serviceaccount/token >/tmp/auth
+      CLUSTER_STATUS=$(curl localhost:8008/cluster)
+      curl localhost:8008/config > /tmp/patroni-config.json
+      PATRONI_ARCHIVE_ENABLED="$(jq -r '.postgresql.parameters.archive_mode == "on"' /tmp/patroni-config.json)"
+      PATRONI_ARCHIVE_COMMAND_SET="$(jq -r '.postgresql.parameters.archive_command != null' /tmp/patroni-config.json)"
+
+      WALG_LAST_BACKUP="$(envdir /etc/wal-g.d/env wal-g backup-list --json 2> /dev/null | jq '.[-1] // {}' -c)"
+      WALG_TIMELINE="$(envdir /etc/wal-g.d/env wal-g wal-verify timeline --json 2>/dev/null)"
+      WALG_INTEGRITY="$(envdir /etc/wal-g.d/env wal-g wal-verify integrity --json 2>/dev/null)"
+
+      REQUEST_JSON="$(echo "{\"cluster_status\": ${CLUSTER_STATUS}, \"patroni_archive_enabled\": ${PATRONI_ARCHIVE_ENABLED}, \"patroni_archive_command_set\": ${PATRONI_ARCHIVE_COMMAND_SET}, \"walg_last_backup\": ${WALG_LAST_BACKUP}, \"walg_timeline\": ${WALG_TIMELINE}, \"walg_integrity\": ${WALG_INTEGRITY}}" | jq -c .)"
+
+      PAYLOAD="[{\"op\" : \"replace\", \"path\" : \"/data/status\", \"value\" : \"${REQUEST_JSON//\"/\\\"}\" }]"
+      curl --cacert ${CA_CERT} --header @/tmp/auth --header "Content-Type: application/json-patch+json" --request PATCH --data "${PAYLOAD}" \
+      https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/status-${STATUS_NAME}
+
+      echo "status updated"
+    else
+      echo "Not eligable, I am replica"
+    fi

--- a/scripts/k8s-patroni
+++ b/scripts/k8s-patroni
@@ -2,8 +2,10 @@
 # [This file is part of the zabbix-agent-osso package]
 # REQUIRES: kubectl
 #
-#UserParameter=k8s-patroni.discovery, sudo /etc/zabbix/scripts/k8s-patroni --discover
-#UserParameter=k8s-patroni.values[*], sudo /etc/zabbix/scripts/k8s-patroni "$1" "$2" "$3" "$4"
+#UserParameter=k8s-patroni.discovery-members, sudo /etc/zabbix/scripts/k8s-patroni --discover-members
+#UserParameter=k8s-patroni.values-members[*], sudo /etc/zabbix/scripts/k8s-patroni --get-member "$1" "$2" "$3" "$4"
+#UserParameter=k8s-patroni.discovery-clusters, sudo /etc/zabbix/scripts/k8s-patroni --discover-clusters
+#UserParameter=k8s-patroni.values-clusters[*], sudo /etc/zabbix/scripts/k8s-patroni --get-cluster "$1" "$2" "$3"
 #
 
 get_contexts() {
@@ -11,34 +13,67 @@ get_contexts() {
 }
 
 get_namespaces() {
-    kubectl --context "$1" get namespace \
-            -l ossobv/zabbix-agent-osso.k8s-patroni=true \
-            --no-headers 2>/dev/null |
+    kubectl get namespace -l ossobv/zabbix-agent-osso.k8s-patroni=true \
+            --context "$1" -oname 2>/dev/null |
         sed -e 's/namespace\///'
 }
 
 get_configmaps() {
     kubectl --context "$1" -n "$2" get cm -o name |
-        sed -e 's/^configmap\///;/^status-/!d'
+        sed -e 's/^configmap\///;/^status-citus-/!d'
 }
 
-make_json() {
+make_json_clusters() {
+     echo '{"{#CONTEXT}":"'$1'","{#NAMESPACE}":"'$2'",'"\
+        "'"{#CONFIGMAP}":"'$3'","{#CLUSTER}":"'${3##status-}'"}'
+}
+
+make_json_members() {
     kubectl --context "$1" -n "$2" get cm "$3" \
             -o jsonpath='{.data.status}' |
-        jq -r '.members[] | {"{#CONTEXT}":"'$1'","{#NAMESPACE}":"'$2'",'"\
-"'"{#POD}":"'$3'","{#MEMBER}":.name}'
+        jq -r '.cluster_status.members[] | {"{#CONTEXT}":"'$1'",'"\
+            "'"{#NAMESPACE}":"'$2'","{#CONFIGMAP}":"'$3'",'"\
+            "'"{#CLUSTER}":"'${3##status-}'","{#MEMBER}":.name}'
 }
 
-if [ "$1" = "--discover" ]; then
+if [ "$1" = "--discover-clusters" ]; then
     for context in $(get_contexts); do
         for namespace in $(get_namespaces "$context"); do
-            for name in $(get_configmaps "$context" "$namespace"); do
-                make_json "$context" "$namespace" "${name#status-}"
+            for configmap in $(get_configmaps "$context" "$namespace"); do
+                make_json_clusters "$context" "$namespace" "$configmap"
             done
         done
     done | jq -sc
     exit 0
-fi
 
-exec kubectl --context "$1" -n "$2" get cm "status-$3" \
-    -o jsonpath='{.data.status}' | jq '.members[] | select(.name == "'"$4"'")'
+elif [ "$1" = "--discover-members" ]; then
+    for context in $(get_contexts); do
+        for namespace in $(get_namespaces "$context"); do
+            for configmap in $(get_configmaps "$context" "$namespace"); do
+                make_json_members "$context" "$namespace" "$configmap"
+            done
+        done
+    done | jq -sc
+    exit 0
+
+elif [ "$1" = "--get-member" ]; then
+    exec kubectl --context "$2" -n "$3" get cm "$4" \
+        -o jsonpath='{.data.status}' \
+        | jq '.cluster_status.members[] | select(.name == "'"$5"'")'
+    exit 0
+
+
+elif [ "$1" = "--get-cluster" ]; then
+    exec kubectl --context "$2" -n "$3" get cm "$4" -o jsonpath='{.data.status}'
+    exit 0
+
+
+else
+    echo "possible options:
+    --discover-clusters     no paramaters
+    --discover-members      no paramaters
+
+    --get-member  context namespace configmap member_name
+    --get-cluster context namespace configmap"
+    exit 1
+fi

--- a/templates/Template k8s-patroni.xml
+++ b/templates/Template k8s-patroni.xml
@@ -19,11 +19,174 @@
             </groups>
             <discovery_rules>
                 <discovery_rule>
-                    <uuid>f690a7b15b744ca7aac4f6329a38941e</uuid>
-                    <name>Postgres status discovery</name>
-                    <key>k8s-patroni.discovery</key>
+                    <uuid>41fb33d165db4792b865e44e90e26668</uuid>
+                    <name>patroni cluster discovery</name>
+                    <key>k8s-patroni.discovery-clusters</key>
                     <delay>1h</delay>
-                    <description>discovery of the postgres statuses</description>
+                    <description>discovery of the postgres clusters</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>d48c7f3495e44cd3ace93c46940c01d1</uuid>
+                            <name>patroni cluster status {#CLUSTER} patroni_archive_command_set</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.patroni_archive_command_set[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.patroni_archive_command_set</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values-clusters[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>8fbd295f2d06451cb11a4f87bab51016</uuid>
+                                    <expression>find(/Template k8s-patroni postgres status/k8s-patroni.patroni_archive_command_set[{#CONTEXT},{#NAMESPACE},{#CLUSTER}],1,&quot;regexp&quot;,&quot;true&quot;)=0</expression>
+                                    <name>postgres cluster {#CLUSTER} patroni_archive_command_set NOT true</name>
+                                    <priority>DISASTER</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>6266d7eb9a504b9ba07da44fa94e49f5</uuid>
+                                    <expression>find(/Template k8s-patroni postgres status/k8s-patroni.patroni_archive_command_set[{#CONTEXT},{#NAMESPACE},{#CLUSTER}],1,&quot;regexp&quot;,&quot;true&quot;)=0</expression>
+                                    <name>postgres cluster {#CLUSTER} patroni_archive_enabled NOT true</name>
+                                    <priority>DISASTER</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>8648e9d7014c4b98ae2e872f9a96334f</uuid>
+                            <name>patroni cluster status {#CLUSTER} patroni_archive_enabled</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.patroni_archive_enabled[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.patroni_archive_enabled</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values-clusters[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>e376a9c5cfc34d52be25f1043bce0490</uuid>
+                            <name>patroni cluster status {#CLUSTER}</name>
+                            <key>k8s-patroni.values-clusters[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            <history>0</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>caa485685f0d40daa535b30020e6c636</uuid>
+                            <name>patroni cluster {#CLUSTER} walg_integrity status</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.walg_integrity[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.walg_integrity.integrity.status</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values-clusters[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>a958010862e24795b6072fd1c91038f1</uuid>
+                                    <expression>last(/Template k8s-patroni postgres status/k8s-patroni.walg_integrity[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}], #1)&lt;&gt;&quot;OK&quot; and last(/Template k8s-patroni postgres status/k8s-patroni.walg_integrity[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}], #2)&lt;&gt;&quot;OK&quot;</expression>
+                                    <name>postgres cluster {#CLUSTER} walg_integrity status NOT ok</name>
+                                    <priority>DISASTER</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>afc98fe5de9d4acd8583a4bb64548a7d</uuid>
+                            <name>patroni cluster {#CLUSTER} walg_last_backup time</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.walg_last_backup[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.walg_last_backup.time</parameter>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>JAVASCRIPT</type>
+                                    <parameters>
+                                        <parameter>const date = new Date(value);
+const timestampSeconds = Math.floor(date.getTime() / 1000);
+return(timestampSeconds)</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values-clusters[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>30448abaf11e4e4dbd773493a42426b7</uuid>
+                                    <expression>(now()-last(/Template k8s-patroni postgres status/k8s-patroni.walg_last_backup[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]))&gt;691200</expression>
+                                    <name>postgres cluster {#CLUSTER} last backup more than a week old</name>
+                                    <priority>DISASTER</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>9d3236b20db94568bdf6ca9ed55e49bc</uuid>
+                            <name>patroni cluster {#CLUSTER} walg_timeline status</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-patroni.walg_timeline[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            <delay>0</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.walg_timeline.timeline.status</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-patroni.values-clusters[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>658cd9c93c984e5c9e37a868a2020e71</uuid>
+                                    <expression>find(/Template k8s-patroni postgres status/k8s-patroni.walg_timeline[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}],5,&quot;regexp&quot;,&quot;OK&quot;)=0</expression>
+                                    <name>postgres cluster {#CLUSTER} walg_timeline status NOT ok</name>
+                                    <priority>DISASTER</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>f690a7b15b744ca7aac4f6329a38941e</uuid>
+                    <name>patroni member discovery</name>
+                    <key>k8s-patroni.discovery-members</key>
+                    <delay>1h</delay>
+                    <description>discovery of the postgres member statuses</description>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>d3cf71eb43ad4c61b07c549b33530c59</uuid>
@@ -44,7 +207,7 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                                <key>k8s-patroni.values-members[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
@@ -73,7 +236,7 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                                <key>k8s-patroni.values-members[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
@@ -109,7 +272,7 @@
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                                <key>k8s-patroni.values-members[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             </master_item>
                             <trigger_prototypes>
                                 <trigger_prototype>
@@ -124,7 +287,7 @@
                         <item_prototype>
                             <uuid>b1d3cb168cd047eba5730f463c980cc9</uuid>
                             <name>patroni-status {#MEMBER}</name>
-                            <key>k8s-patroni.values[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
+                            <key>k8s-patroni.values-members[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}]</key>
                             <history>0</history>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>

--- a/zabbix_agentd.d/k8s-patroni.conf
+++ b/zabbix_agentd.d/k8s-patroni.conf
@@ -1,7 +1,9 @@
 # [This file is part of the zabbix-agent-osso package]
 #
-# DEPENDS: kubectl
+# DEPENDS: kubectl, jq
 # SCRIPTS: k8s-patroni
 #
-UserParameter=k8s-patroni.discovery, sudo /etc/zabbix/scripts/k8s-patroni --discover
-UserParameter=k8s-patroni.values[*], sudo /etc/zabbix/scripts/k8s-patroni "$1" "$2" "$3" "$4"
+UserParameter=k8s-patroni.discovery-members, sudo /etc/zabbix/scripts/k8s-patroni --discover-members
+UserParameter=k8s-patroni.values-members[*], sudo /etc/zabbix/scripts/k8s-patroni --get-member "$1" "$2" "$3" "$4"
+UserParameter=k8s-patroni.discovery-clusters, sudo /etc/zabbix/scripts/k8s-patroni --discover-clusters
+UserParameter=k8s-patroni.values-clusters[*], sudo /etc/zabbix/scripts/k8s-patroni --get-cluster "$1" "$2" "$3"


### PR DESCRIPTION
adds items for last full backup, wal-g timeline and integrity status, and patroni archive commands. with acompanying triggers.

config example updated with new script
latest version of zabbix template
script now prints a help when no params are passed