### PR TITLE
k8s-redis: updates to template as used now in zabbix

### DIFF
--- a/templates/Template k8s-redis.xml
+++ b/templates/Template k8s-redis.xml
@@ -47,7 +47,7 @@
                                 <trigger_prototype>
                                     <uuid>9b18d32333f2440c9c990fd3454cc8a8</uuid>
                                     <expression>change(/Template k8s-redis status/k8s-redis.master_failover_state[{#CONTEXT},{#NAMESPACE},{#POD}])=1</expression>
-                                    <name>redisfailover master_failover_state_changed {#CONFIGMAP} in namespace {#NAMESPACE}</name>
+                                    <name>redisfailover master_failover_state_changed {#POD} in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                 </trigger_prototype>
                             </trigger_prototypes>
@@ -77,7 +77,7 @@
                                 <trigger_prototype>
                                     <uuid>a13bae3b97724feaae32862b5937b825</uuid>
                                     <expression>change(/Template k8s-redis status/k8s-redis.master_link_status[{#CONTEXT},{#NAMESPACE},{#POD}])=1</expression>
-                                    <name>redisfailover {#CONFIGMAP} master_link_status changed in namespace {#NAMESPACE}</name>
+                                    <name>redisfailover {#POD} master_link_status changed in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                 </trigger_prototype>
                             </trigger_prototypes>
@@ -125,7 +125,7 @@
                                 <trigger_prototype>
                                     <uuid>3ece973bdb864aae8319940eb9e428a1</uuid>
                                     <expression>change(/Template k8s-redis status/k8s-redis.role[{#CONTEXT},{#NAMESPACE},{#POD}])=1</expression>
-                                    <name>redisfailover role changed {#CONFIGMAP} in namespace {#NAMESPACE}</name>
+                                    <name>redisfailover role changed {#POD} in namespace {#NAMESPACE}</name>
                                     <priority>DISASTER</priority>
                                 </trigger_prototype>
                             </trigger_prototypes>
@@ -134,7 +134,7 @@
                             <uuid>908308c540bc40c19519e6401fa96ea6</uuid>
                             <name>redis failover {#POD}</name>
                             <key>k8s-redis.values[{#CONTEXT},{#NAMESPACE},{#POD}]</key>
-                            <history>0</history>
+                            <history>1h</history>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                         </item_prototype>


### PR DESCRIPTION
template currently does not match with script. 
this is the template used in OSSO zabbix currently