### PR TITLE
Add local haproxy monitoring on k8s hosts

### DIFF
--- a/scripts/k8s-haproxy-healthcheck
+++ b/scripts/k8s-haproxy-healthcheck
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Script for healthchecking our local haproxy -> kube-api
+# returns 1 if /healthz returns 'ok'
+# returns 0 if anything else
+
+pkipath=/etc/kubernetes/pki
+cacert=$pkipath/ca.crt
+curl_args="--silent --max-time 5"
+url="http://127.0.0.1:8080/healthz"
+cert_args=""
+
+# Use admin cert on master nodes and kubelet cert on worker nodes.
+# If there are no certs use http without a certificate.
+for name in $pkipath/admin $pkipath/kubelet; do
+    if test -e $name.crt; then
+        url="https://127.0.0.1:8443/healthz"
+        cert_args="--cacert $cacert --key $name.key --cert $name.crt"
+        break
+    fi
+done
+
+if test "$(curl $curl_args $cert_args $url)" = 'ok'; then
+    echo 1
+else
+    echo 0
+fi

--- a/zabbix_agentd.d/k8s-haproxy.conf
+++ b/zabbix_agentd.d/k8s-haproxy.conf
@@ -1,0 +1,1 @@
+UserParameter=k8s.haproxy-healthcheck, /etc/zabbix/scripts/k8s-haproxy-healthcheck


### PR DESCRIPTION
Adds a healthcheck that uses certificates to connect to the Kubernetes API via local haproxy on the worker/controlplane nodes. Request is made to . Returns 1 if all is well, returns 0 if something is wrong.