### PR TITLE
K8s-pods-ready: fix the naming inconsistencies

### DIFF
--- a/config/k8s-pods-ready.txt
+++ b/config/k8s-pods-ready.txt
@@ -1,13 +1,13 @@
 # [This file is part of the zabbix-agent-osso package]
-k8s-pod-ready
+k8s-pods-ready
 ==============
 
 this script monitors the readiness of the containers in pods, configured by labels on a namespace
 
 to enable this for a namespace label the namespace with:
-ossobv/zabbix-agent-osso.k8s-pod-ready=true
+ossobv/zabbix-agent-osso.k8s-pods-ready=true
 
 to setup for what pods the script should check the container statuses use the following label:
-ossobv/zabbix-agent-osso.k8s-pod-ready-startswith=natsomatch
+ossobv/zabbix-agent-osso.k8s-pods-ready-startswith=natsomatch
 
 in this example it matches all pods with names that start with `natsomatch`

--- a/scripts/k8s-pods-ready
+++ b/scripts/k8s-pods-ready
@@ -8,7 +8,7 @@ get_contexts() {
 }
 
 get_namespaces() {
-    kubectl get namespace -l ossobv/zabbix-agent-osso.k8s-pod-ready=true \
+    kubectl get namespace -l ossobv/zabbix-agent-osso.k8s-pods-ready=true \
             --context "$1" -oname 2>/dev/null |
         sed -e 's/namespace\///'
 }
@@ -18,7 +18,7 @@ if [ "$1" = "--discover" ]; then
         for namespace in $(get_namespaces "$context"); do
             startswith=$(kubectl --context $context get namespace $namespace \
                 -ojsonpath='{.metadata.labels}' |
-                jq -r '."ossobv/zabbix-agent-osso.k8s-pod-ready-startswith"')
+                jq -r '."ossobv/zabbix-agent-osso.k8s-pods-ready-startswith"')
             echo '{"{#CONTEXT}":"'$context'","{#NAMESPACE}":"'$namespace'",'"\
                 "'"{#STARTSWITH}":"'$startswith'"}'
         done

--- a/sudoers.d/zabbix-k8s-pods-ready
+++ b/sudoers.d/zabbix-k8s-pods-ready
@@ -1,6 +1,6 @@
 # [This file is part of the zabbix-agent-osso package]
 #
-Cmnd_Alias K8S_POD_READY = /etc/zabbix/scripts/k8s-pod-ready *
+Cmnd_Alias K8S_PODS_READY = /etc/zabbix/scripts/k8s-pods-ready *
 Defaults!K8S_POD_READY !log_allowed, !pam_session
-zabbix ALL=NOPASSWD: K8S_POD_READY
+zabbix ALL=NOPASSWD: K8S_PODS_READY
 

--- a/templates/k8s-pods-ready.xml
+++ b/templates/k8s-pods-ready.xml
@@ -10,8 +10,8 @@
     <templates>
         <template>
             <uuid>a3dab75daa044c62a27213adc46b3661</uuid>
-            <template>k8s-pod-ready</template>
-            <name>k8s-pod-ready</name>
+            <template>k8s-pods-ready</template>
+            <name>k8s-pods-ready</name>
             <groups>
                 <group>
                     <name>Templates</name>
@@ -20,20 +20,20 @@
             <discovery_rules>
                 <discovery_rule>
                     <uuid>dcf4207059ab42548f44e0a0ca9aa4be</uuid>
-                    <name>k8s-pod-ready discovery</name>
-                    <key>k8s-pod-ready.discovery</key>
+                    <name>k8s-pods-ready discovery</name>
+                    <key>k8s-pods-ready.discovery</key>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>dbb097e69711427dbe168578f60f17b8</uuid>
-                            <name>k8s-pod-ready values</name>
-                            <key>k8s-pod-ready.values[{#CONTEXT},{#NAMESPACE},{#STARTSWITH}]</key>
+                            <name>k8s-pods-ready values</name>
+                            <key>k8s-pods-ready.values[{#CONTEXT},{#NAMESPACE},{#STARTSWITH}]</key>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                             <description>boolean, true is all pods are ready</description>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>29c651fc92b44b8d88607f0e03b3d1cc</uuid>
-                                    <expression>last(/k8s-pod-ready/k8s-pod-ready.values[{#CONTEXT},{#NAMESPACE},{#STARTSWITH}])=&quot;false&quot;</expression>
+                                    <expression>last(/k8s-pods-ready/k8s-pods-ready.values[{#CONTEXT},{#NAMESPACE},{#STARTSWITH}])=&quot;false&quot;</expression>
                                     <name>{#CONTEXT}: {#STARTSWITH} pods in namespace {#NAMESPACE} are not ready</name>
                                     <priority>DISASTER</priority>
                                 </trigger_prototype>

--- a/zabbix_agentd.d/k8s-pods-ready.conf
+++ b/zabbix_agentd.d/k8s-pods-ready.conf
@@ -3,6 +3,6 @@
 # DEPENDS: kubectl, jq
 # SCRIPTS: k8s-pods-ready
 #
-UserParameter=k8s-pod-ready.discovery, sudo /etc/zabbix/scripts/k8s-pod-ready --discover
-UserParameter=k8s-pod-ready.values[*], sudo /etc/zabbix/scripts/k8s-pod-ready --get-values "$1" "$2" "$3"
+UserParameter=k8s-pods-ready.discovery, sudo /etc/zabbix/scripts/k8s-pods-ready --discover
+UserParameter=k8s-pods-ready.values[*], sudo /etc/zabbix/scripts/k8s-pods-ready --get-values "$1" "$2" "$3"
 


### PR DESCRIPTION
current version mixed k8s-pod-ready and k8s-pods-ready resulting in errors. change all to k8s-pods-ready