### PR TITLE
k8s-patroni adjust configmap naming to discover

### DIFF
--- a/scripts/k8s-patroni
+++ b/scripts/k8s-patroni
@@ -15,7 +15,7 @@ get_namespaces() {
 
 get_configmaps() {
     kubectl --context "$1" -n "$2" get cm -o name |
-        sed -e 's/^configmap\///;/^status-citus-/!d'
+        sed -e 's/^configmap\///;/^status-\(citus\|postgres\)-/!d'
 }
 
 make_json_clusters() {


### PR DESCRIPTION
the status-scraper script is also in use for not citus clusters, so we want to disover both status-citus-x and status-postgres-x configmaps in a labled namespace