### PR TITLE
feat: add k8s-galera monitoring

### DIFF
--- a/config/k8s-galera.txt
+++ b/config/k8s-galera.txt
@@ -1,0 +1,20 @@
+# [This file is part of the zabbix-agent-osso package]
+
+# k8s-galera
+
+The k8s galera monitoring script monitors galera clusters setup with the mariadb operator for kubernetes.
+The script gets its status information from the mariadb cluster CRD inside your kubernetes cluster.
+
+For more information about the mariadb kubernetes operator, visit the [project homepage](https://github.com/mariadb-operator/mariadb-operator).
+
+Before setting up galera monitoring make sure your hosts have the following packages installed:
+
+- `jq`
+- `kubectl`
+
+To setup galera monitoring perform the following steps:
+
+1. Add the following label to any namespace containing a galera cluster:
+   `ossobv/zabbix-agent-osso.k8s-galera=true`
+
+2. Add the `Template k8s-galera.xml` template to your hosts in the zabbix interface.

--- a/scripts/k8s-galera
+++ b/scripts/k8s-galera
@@ -1,0 +1,73 @@
+#!/bin/sh
+# [This file is part of the zabbix-agent-osso package]
+# REQUIRES: jq, kubectl
+#
+
+get_contexts() {
+    kubectl config get-contexts -oname
+}
+
+get_namespaces() {
+    kubectl --context "$1" get namespace \
+        -l ossobv/zabbix-agent-osso.k8s-galera=true \
+        -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' \
+        2>/dev/null
+}
+
+get_clusters() {
+    kubectl --context "$1" -n "$2" \
+        get mariadbs.k8s.mariadb.com -oname 2>/dev/null |
+        cut -d'/' -f2
+}
+
+make_json_clusters() {
+    echo '{"{#CONTEXT}":"'$1'","{#NAMESPACE}":"'$2'",'"\
+        "'"{#CLUSTER}":"'$3'"}'
+}
+
+make_json_cluster_status() {
+    json=$(kubectl --context "$1" -n "$2" get mariadbs.k8s.mariadb.com "$3" \
+        -o json |
+            jq -c '{
+                current_primary_pod_index: .status.currentPrimaryPodIndex,
+                current_replica_count: .status.replicas,
+                galera_ready: (.status.conditions[] |
+                    select(.reason == "GaleraReady") | .status),
+                desired_replica_count: .spec.replicas,
+                sts_ready: (.status.conditions[] |
+                    select(.reason == "StatefulSetReady") | .status)
+            }')
+
+    if [ -z "$json" ]; then
+        echo '{"current_primary_pod_index":"0",'"\
+            "'"current_replica_count":"0",'"\
+            "'"galera_ready":"False",'"\
+            "'"desired_replica_count":"0",'"\
+            "'"sts_ready":"False"}'
+    else
+        echo "$json"
+    fi
+}
+
+
+if [ "$1" = "--discover-clusters" ]; then
+    for context in $(get_contexts); do
+        for namespace in $(get_namespaces "$context"); do
+            for cluster in $(get_clusters "$context" "$namespace"); do
+                make_json_clusters "$context" "$namespace" "$cluster"
+            done
+        done
+    done | jq -sc
+    exit 0
+
+elif [ "$1" = "--get-cluster" ]; then
+    make_json_cluster_status "$2" "$3" "$4"
+    exit 0
+
+else
+    echo "possible actions:
+    --discover-clusters
+
+    --get-cluster context namespace cluster" >&2
+    exit 1
+fi

--- a/sudoers.d/zabbix-k8s-galera
+++ b/sudoers.d/zabbix-k8s-galera
@@ -1,0 +1,5 @@
+# [This file is part of the zabbix-agent-osso package]
+#
+Cmnd_Alias GALERA = /etc/zabbix/scripts/k8s-galera *
+Defaults!GALERA !log_allowed, !pam_session
+zabbix ALL=NOPASSWD: GALERA

--- a/templates/Template k8s-galera.xml
+++ b/templates/Template k8s-galera.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>6.4</version>
+    <template_groups>
+        <template_group>
+            <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+            <name>Templates/Applications</name>
+        </template_group>
+    </template_groups>
+    <templates>
+        <template>
+            <uuid>dfb8263cf05842f5bc3d8d7f3f11bcbf</uuid>
+            <template>Template k8s-galera mariadb status</template>
+            <name>Template k8s-galera mariadb status</name>
+            <groups>
+                <group>
+                    <name>Templates/Applications</name>
+                </group>
+            </groups>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>b1134c1839a5481eb653131795ad65ce</uuid>
+                    <name>Galera cluster discovery</name>
+                    <type>ZABBIX_ACTIVE</type>
+                    <key>k8s-galera.discover-clusters</key>
+                    <delay>1h</delay>
+                    <description>Discovery of the mariadb clusters</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>0c03b14cfb904f8aaef6a74b493b3598</uuid>
+                            <name>Galera cluster status {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} current_primary_pod_index</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-galera.current_primary_pod_index[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            <delay>0</delay>
+                            <history>1d</history>
+                            <value_type>TEXT</value_type>
+                            <trends>0</trends>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.current_primary_pod_index</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-galera.values-clusters[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>3dc862e0a0ee4cd7ac9160a97e55fd34</uuid>
+                                    <expression>change(/Template k8s-galera mariadb status/k8s-galera.current_primary_pod_index[{#CONTEXT},{#NAMESPACE},{#CLUSTER}])=1</expression>
+                                    <name>Galera {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} primary pod changed</name>
+                                    <priority>DISASTER</priority>
+                                    <description>The primary galera pod changed</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>c529c403c1c347da87deadca49fe0c5a</uuid>
+                            <name>Galera cluster status {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} current_replica_count</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-galera.current_replica_count[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            <delay>0</delay>
+                            <history>1d</history>
+                            <value_type>TEXT</value_type>
+                            <trends>0</trends>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.current_replica_count</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-galera.values-clusters[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>6a9217c4869a4e4eb14d0501eea24514</uuid>
+                            <name>Galera cluster status {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} desired_replica_count</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-galera.desired_replica_count[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            <delay>0</delay>
+                            <history>1d</history>
+                            <value_type>TEXT</value_type>
+                            <trends>0</trends>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.desired_replica_count</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-galera.values-clusters[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>f0a7572b28844f13b41eb5e2220172fb</uuid>
+                            <name>Galera cluster status {#CONTEXT}:{#NAMESPACE}:{#CLUSTER}</name>
+                            <key>k8s-galera.values-clusters[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            <history>1d</history>
+                            <value_type>TEXT</value_type>
+                            <trends>0</trends>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>25c7d11ad7914a68b437e23d7c999ac7</uuid>
+                            <name>Galera cluster status {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} statefulsets_ready</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-galera.sts_ready[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            <delay>0</delay>
+                            <history>1d</history>
+                            <value_type>TEXT</value_type>
+                            <trends>0</trends>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.sts_ready</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-galera.values-clusters[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            </master_item>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>6cca177db16f4c85a3b941c7847c61d3</uuid>
+                            <name>Galera cluster status {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} galera_ready</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s-galera.galera_ready[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            <delay>0</delay>
+                            <history>1d</history>
+                            <value_type>TEXT</value_type>
+                            <trends>0</trends>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.galera_ready</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s-galera.values-clusters[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>4117b5e785c04152bc0645e0239cde13</uuid>
+                                    <expression>last(/Template k8s-galera mariadb status/k8s-galera.galera_ready[{#CONTEXT},{#NAMESPACE},{#CLUSTER}])=&quot;False&quot;</expression>
+                                    <name>Galera {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} galera status not ready</name>
+                                    <priority>DISASTER</priority>
+                                    <description>Galera is not ready</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>ca1f90d277f64dc291b86698cb295fb1</uuid>
+                                    <expression>last(/Template k8s-galera mariadb status/k8s-galera.galera_ready[{#CONTEXT},{#NAMESPACE},{#CLUSTER}])=&quot;False&quot;</expression>
+                                    <name>Galera {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} statefulsets are not ready</name>
+                                    <priority>DISASTER</priority>
+                                    <description>Galera statefullsets are not ready</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <uuid>9fa67ad96f584e0a9600b997596db986</uuid>
+                            <expression>last(/Template k8s-galera mariadb status/k8s-galera.current_replica_count[{#CONTEXT},{#NAMESPACE},{#CLUSTER}]) &lt;&gt; last(/Template k8s-galera mariadb status/k8s-galera.desired_replica_count[{#CONTEXT},{#NAMESPACE},{#CLUSTER}])</expression>
+                            <name>Galera {#CONTEXT}:{#NAMESPACE}:{#CLUSTER} replicas different than expected</name>
+                            <priority>DISASTER</priority>
+                            <description>Galera replica count is different compared to what is expected</description>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+            <tags>
+                <tag>
+                    <tag>application</tag>
+                    <value>galera</value>
+                </tag>
+            </tags>
+        </template>
+    </templates>
+</zabbix_export>

--- a/zabbix_agentd.d/k8s-galera.conf
+++ b/zabbix_agentd.d/k8s-galera.conf
@@ -1,0 +1,7 @@
+# [This file is part of the zabbix-agent-osso package]
+#
+# DEPENDS: jq, kubectl
+# SCRIPTS: k8s-galera
+#
+UserParameter=k8s-galera.discover-clusters, sudo /etc/zabbix/scripts/k8s-galera --discover-clusters
+UserParameter=k8s-galera.values-clusters[*], sudo /etc/zabbix/scripts/k8s-galera --get-cluster "$1" "$2" "$3"


### PR DESCRIPTION
This PR seeks to add support for monitoring galera clusters that have been setup using the official mariadb operator for kubernetes.

[Find more info about the operator here](https://github.com/mariadb-operator/mariadb-operator/)