### PR TITLE
K8S patroni postgres: Add better no update trigger

### DIFF
--- a/config/k8s-patroni.md
+++ b/config/k8s-patroni.md
@@ -6,7 +6,7 @@ The k8s patroni monitoring works by running a script as a sidecar, or in a cronj
 This script writes all statuses available in the container to a configmap.
 These configmaps are then automatically discovered by the zabbix-agent.
 
-To setup patroni monitoring you have to follow these steps:
+To setup patroni monitoring you have to follow the following steps:
 
 1. Label the namespaces to be monitored with:
    `ossobv/zabbix-agent-osso.k8s-patroni=true`.
@@ -16,52 +16,86 @@ To setup patroni monitoring you have to follow these steps:
     If you use the script in a cronjob we advise using `run-one` and `timeout`:
 
     ```cron
-    * * * * * postgres run-one timeout 1m envdir /tmp/scripts/postgres-status.sh
+    * * * * * postgres run-one timeout 1m /tmp/scripts/postgres-status.sh
     ```
+    
+    Or when using the zalando postgres operator you can use the our custom sidecar image:   [Zalando-postgres-scraper](https://git.osso.nl/pub/docker/zalando-postgres-scraper).
+    This image includes the script, and needs wal-g environment settings.
+    See the project's README for an example.
 
 3. Give this sidecar a serviceaccount that can create configmaps.
-
     - You have to manually create the configmaps the first time:
       `kubectl create cm status-<status_name> --from-literal status=null`
     - The serviceaccount only needs patch permissions, and can be limited
       to only the monitored namespaces.
 
-4. Mount the following script to the sidecar, and make it run every 30 seconds.
+4. Mount the postgres-status.sh script to the sidecar.
+    The latest version of the script can be found [here](https://git.osso.nl/pub/docker/zalando-postgres-scraper/-/blob/master/postgres-status.sh)
 
-    ```sh
-    #!/bin/bash
-    umask 0077
-    ROLE=$(curl -s http://localhost:8008 | jq -r .role)
-    # there is only one master, use this to prevent double status checks.
-    if test $ROLE == "master"; then
-        CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
-        sed -e 's/^/Authorization: Bearer /' /var/run/secrets/kubernetes.io/serviceaccount/token >/tmp/auth
-        CLUSTER_STATUS=$(curl localhost:8008/cluster)
-        curl localhost:8008/config > /tmp/patroni-config.json
-        PATRONI_ARCHIVE_ENABLED="$(jq -r '.postgresql.parameters.archive_mode == "on"' /tmp/patroni-config.json)"
-        PATRONI_ARCHIVE_COMMAND_SET="$(jq -r '.postgresql.parameters.archive_command != null' /tmp/patroni-config.json)"
-
-        WALG_LAST_BACKUP="$(envdir /etc/wal-g.d/env wal-g backup-list --json 2> /dev/null | jq '.[-1] // {}' -c)"
-        WALG_TIMELINE="$(envdir /etc/wal-g.d/env wal-g wal-verify timeline --json 2>/dev/null)"
-        WALG_INTEGRITY="$(envdir /etc/wal-g.d/env wal-g wal-verify integrity --json 2>/dev/null)"
-
-        REQUEST_JSON="$(echo "{\"cluster_status\": ${CLUSTER_STATUS}, \"patroni_archive_enabled\": ${PATRONI_ARCHIVE_ENABLED}, \"patroni_archive_command_set\": ${PATRONI_ARCHIVE_COMMAND_SET}, \"walg_last_backup\": ${WALG_LAST_BACKUP}, \"walg_timeline\": ${WALG_TIMELINE}, \"walg_integrity\": ${WALG_INTEGRITY}}" | jq -c .)"
-
-        PAYLOAD="[{\"op\" : \"replace\", \"path\" : \"/data/status\", \"value\" : \"${REQUEST_JSON//\"/\\\"}\" }]"
-        curl --cacert ${CA_CERT} --header @/tmp/auth --header "Content-Type: application/json-patch+json" --request PATCH --data "${PAYLOAD}" \
-        https://kubernetes.default.svc:443/api/v1/namespaces/${POD_NAMESPACE}/configmaps/status-${STATUS_NAME}
-
-        echo "status updated"
-    else
-        echo "Not eligable, I am replica"
-    fi
+5. The configmap should now be filled by the script. A truncated example of the json content:
+    ```json
+    {
+      "cluster_status": {
+        "members": [
+          {
+            "name": "acid-postgres-0",
+            "role": "replica",
+            "state": "streaming",
+            "api_url": "http://1.2.3.4:8008/patroni",
+            "host": "1.2.3.4",
+            "port": 5432,
+            "timeline": 10,
+            "lag": 0
+          } 
+          ...
+        ],
+        "scope": "acid-postgres"
+      },
+      "patroni_archive_enabled": true,
+      "patroni_archive_command_set": false,
+      "walg_last_backup": {
+        "backup_name": "base_0000000A00000007000000D1",
+        "time": "2025-02-17T18:22:45.192Z",
+        "wal_file_name": "0000000A00000007000000D1",
+        "storage_name": "default"
+      },
+      "walg_timeline": {
+        "timeline": {
+          "status": "OK",
+          "details": {
+            "current_timeline_id": 10,
+            "highest_storage_timeline_id": 10
+          }
+        }
+      },
+      "walg_integrity": {
+        "integrity": {
+          "status": "FAILURE",
+          "details": [
+            {
+              "timeline_id": 1,
+              "start_segment": "000000010000000000000009",
+              "end_segment": "00000001000000000000003E",
+              "segments_count": 54,
+              "status": "MISSING_LOST"
+            }
+            ...
+          ]
+        }
+      },
+      "current_timestamp": 1739886583
+    }
     ```
 
-5. Load the template and enable the template for the hosts:
+    - For more info on the wal-g output see the [docs](https://wal-g.readthedocs.io/PostgreSQL/)
+
+6. Load the template and enable the template for the hosts:
 
     - The hosts should have `kubectl` installed and have access to the cluster and its namespaces.
-
     - For the wal-g environment variables in cron you can use a mounted secret/configmap at `/etc/wal-g.d/env`,
       here you also define `POD_NAMESPACE` and `STATUS_NAME`.
+    - `STATUS_NAME` needs to start with either `postgres` or `citus`.
     - Patroni is accessed trough `localhost`, because the cli needs multiple environment variables,
       which we don't want to define in an extra configmap (it's a rest api anyways).
+    - Some wal-g commands like `wal-g wal-verify timeline` need a connection to postgres to work,
+    this can be setup with a socket or `PGHOST` env vars.

--- a/templates/Template K8S patroni postgres.xml
+++ b/templates/Template K8S patroni postgres.xml
@@ -55,6 +55,33 @@
                             </master_item>
                         </item_prototype>
                         <item_prototype>
+                            <uuid>664fcf5fea2d4ab38380138c79241d4d</uuid>
+                            <name>K8s patroni cluster current_timestamp {#CLUSTER} ({#NAMESPACE} in {#CONTEXT})</name>
+                            <type>DEPENDENT</type>
+                            <key>k8s.patroni.current_timestamp[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            <delay>0</delay>
+                            <preprocessing>
+                                <step>
+                                    <type>JSONPATH</type>
+                                    <parameters>
+                                        <parameter>$.current_timestamp</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>k8s.patroni.show_cluster[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
+                            </master_item>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>071d6388c1eb4104a66bfeeb15014245</uuid>
+                                    <expression>last(/Template K8S patroni postgres/k8s.patroni.current_timestamp[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]) &lt; (now() - 300)</expression>
+                                    <name>K8S patroni postgres status not updated for 5 minutes on  {#CLUSTER} ({#NAMESPACE} in {#CONTEXT})</name>
+                                    <priority>DISASTER</priority>
+                                    <description>Status is not updated in last 5 minutes</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
                             <uuid>8648e9d7014c4b98ae2e872f9a96334f</uuid>
                             <name>K8s patroni cluster archive_enabled {#CLUSTER} ({#NAMESPACE} in {#CONTEXT})</name>
                             <type>DEPENDENT</type>
@@ -87,7 +114,6 @@
                             <name>K8S patroni postgres cluster status {#CLUSTER} ({#NAMESPACE} on {#CONTEXT})</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>k8s.patroni.show_cluster[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP}]</key>
-                            <delay>1h</delay>
                             <history>0</history>
                             <value_type>TEXT</value_type>
                             <trends>0</trends>
@@ -232,7 +258,7 @@ time()&lt;220000</expression>
                                     <expression>last(/Template K8S patroni postgres/k8s.patroni.lag[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}])&gt;0</expression>
                                     <name>K8S patroni postgres {#MEMBER} replication lag ({#NAMESPACE} in {#CONTEXT})</name>
                                     <opdata>{ITEM.LASTVALUE}</opdata>
-                                    <priority>HIGH</priority>
+                                    <priority>WARNING</priority>
                                 </trigger_prototype>
                             </trigger_prototypes>
                         </item_prototype>
@@ -264,13 +290,6 @@ time()&lt;220000</expression>
                                     <opdata>role: {ITEM.LASTVALUE}</opdata>
                                     <priority>DISASTER</priority>
                                     <description>patroni postgres role changed</description>
-                                </trigger_prototype>
-                                <trigger_prototype>
-                                    <uuid>7bdb1e8c62b5461cbddafd497b06f679</uuid>
-                                    <expression>nodata(/Template K8S patroni postgres/k8s.patroni.role[{#CONTEXT},{#NAMESPACE},{#CONFIGMAP},{#MEMBER}],5m)=1</expression>
-                                    <name>K8S patroni postgres {#MEMBER} maybe not running ({#NAMESPACE} in {#CONTEXT})</name>
-                                    <priority>DISASTER</priority>
-                                    <description>FIXME: the nodata() here means that we haven't read the configmap recently. But we have no idea if the configmap has been updated recently. Because of the nodata(5m) we can also not use &quot;Discard&quot; or &quot;Discard with heartbeat&quot;.</description>
                                 </trigger_prototype>
                             </trigger_prototypes>
                         </item_prototype>


### PR DESCRIPTION
Updated config example to mention zalando-postgres-scraper image Removed old no-data trigger
Added current timestamp to CM script.
Added item and trigger on CM current timestamp
Set lag to warning based on production settings