### PR TITLE
Add list_instances function in mysql2 for discovery of CNF's

### DIFF
--- a/cron.d/zabbix-mysql2
+++ b/cron.d/zabbix-mysql2
@@ -7,4 +7,4 @@ SHELL=/bin/bash
 # Run a daily SELECT ... LIMIT 1; check on all databases.
 # When the database consists of many smaller schemas, we'll run into issues
 # with the duration of the script.
-10 10 * * *  root  sleep $((RANDOM \% 1800)); for CNF in $(find /etc/zabbix/config/ -maxdepth 1 -name 'mysql2.*.cnf' -type f); do CNF=${CNF##*/mysql2.}; CLUSTER="${CNF\%\%.*}"; DST=/var/lib/zabbix/scripts/mysql2.$CLUSTER; /etc/zabbix/scripts/mysql2-select-healthcheck $CLUSTER >$DST.tmp; mv $DST.tmp $DST; done
+10 10 * * *  root  sleep $((RANDOM \% 1800)); for CLUSTER in $(/etc/zabbix/scripts/mysql2 list_instances); do DST=/var/lib/zabbix/scripts/mysql2.$CLUSTER; /etc/zabbix/scripts/mysql2-select-healthcheck $CLUSTER >$DST.tmp; mv $DST.tmp $DST; done

--- a/scripts/mysql2
+++ b/scripts/mysql2
@@ -59,6 +59,23 @@ elif test "$bin" = discover_instances; then
     test -z "$notfirst" && test -s /etc/zabbix/mysql/.my.cnf &&
         echo "{\"{#INSTANCE}\": \"default\", \"{#SEVERITY}\": 5}"
     echo "]"
+elif test "$bin" = list_instances; then
+    notfirst=
+    for cnf in /etc/zabbix/config/mysql2.*.cnf \
+               /etc/zabbix/config/mysql.*.cnf; do
+        if test -s "$cnf"; then
+            if test "${cnf##*/mysql2.}" != "$cnf"; then
+                instance=${cnf##*/mysql2.}
+            else
+                instance=${cnf##*/mysql.}
+            fi
+            instance=${instance%.cnf}
+            echo $instance
+            notfirst=1
+        fi
+    done
+    test -z "$notfirst" && test -s /etc/zabbix/mysql/.my.cnf &&
+        echo default
 elif test "$bin" = no-v2-conf; then
     for cnf in /etc/zabbix/config/mysql2.*.cnf \
                /etc/zabbix/config/mysql.*.cnf; do


### PR DESCRIPTION
This is used by the zabbix-mysql2 cronjob and supports both mysql and mysql2 named configs