### PR TITLE
k8s-pvolume: move discovery to cron because of possible longer execution times

### DIFF
--- a/cron.d/zabbix-k8s-pvolume
+++ b/cron.d/zabbix-k8s-pvolume
@@ -1,0 +1,8 @@
+# [This file is part of the zabbix-agent-osso package]
+
+# We'll set the shell to bash and do a random sleep to avoid all machines
+# running checks at the same exact time.
+SHELL=/bin/bash
+
+# Discovery of PVC's.
+0 * * * *  root  command -v kubectl >/dev/null || exit 0; sleep $((RANDOM \% 1800)); DST=/var/lib/zabbix/scripts/k8s.pvolume.discover_filesystems; /etc/zabbix/scripts/k8s-pvolume discover-filesystems >"$DST.tmp" && mv "$DST.tmp" "$DST"

--- a/zabbix_agentd.d/k8s-pvolume.conf
+++ b/zabbix_agentd.d/k8s-pvolume.conf
@@ -3,5 +3,5 @@
 # DEPENDS: jq, kubectl
 # SCRIPTS: k8s-pvolume
 #
-UserParameter=k8s.pvolume.discover_filesystems, sudo /etc/zabbix/scripts/k8s-pvolume discover-filesystems
+UserParameter=k8s.pvolume.discover_filesystems, cat /var/lib/zabbix/scripts/k8s.pvolume.discover_filesystems
 UserParameter=k8s.pvolume.show_filesystem[*], sudo /etc/zabbix/scripts/k8s-pvolume show-filesystem "$1" "$2" "$3" "$4"


### PR DESCRIPTION
In some cases, `/etc/zabbix/scripts/k8s-pvolume discover-filesystems` can take multiple seconds to execute, because it does a call for each volume in Ceph. Moving it to a cronjob with output written to a file will avoid issues with timeouts in Zabbix.