### PR TITLE
MinIO: Bugfix: offline drives.

### DIFF
--- a/scripts/minio
+++ b/scripts/minio
@@ -128,8 +128,10 @@ def get_global_data(minio_instance):
     disks = []
     for server in admin_info['servers']:
         disks.extend(server['drives'])
+    # Offline drives do not have a `usedspace` property.
     highest_disk_usage = max(
-        [drive['usedspace']/drive['totalspace'] for drive in disks])
+        [drive['usedspace'] / drive['totalspace'] for drive in disks
+         if drive['state'] == 'ok'])
 
     failed_decoms = sum(
         1 for decom in decom_info if decom['decommissionInfo']['failed'])

--- a/templates/Template App MinIO.xml
+++ b/templates/Template App MinIO.xml
@@ -45,7 +45,7 @@
                                 <step>
                                     <type>JSONPATH</type>
                                     <parameters>
-                                        <parameter>$.any_failed_decom_bytes</parameter>
+                                        <parameter>$.failed_decom_bytes</parameter>
                                     </parameters>
                                 </step>
                             </preprocessing>
@@ -64,7 +64,7 @@
                                 <step>
                                     <type>JSONPATH</type>
                                     <parameters>
-                                        <parameter>$.any_failed_decoms</parameter>
+                                        <parameter>$.failed_decoms</parameter>
                                     </parameters>
                                 </step>
                             </preprocessing>


### PR DESCRIPTION
Offline drives do not have an `usedspace` property resulting in a keyerror. Also fixed a small issue in the template.